### PR TITLE
Add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,
+    package_data={"gltflib":["py.typed"]},
     license='MIT',
     classifiers=[
         # Trove classifiers


### PR DESCRIPTION
I noticed my project using gltflib wasn't mypying properly; this pull request adds the required py.typed file so the type annotations get used by the users of this library.